### PR TITLE
Implement Recommend Tracks Endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "[python]": {
     "editor.tabSize": 4,
-    "editor.insertSpaces": false,
+    "editor.insertSpaces": true,
     "editor.detectIndentation": false
   }
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 pytest==7.1.3
 Flask==2.2.2
 Flask-Cors==3.0.10
+requests==2.28.1
+python-dotenv==0.21.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,4 +2,3 @@ pytest==7.1.3
 Flask==2.2.2
 Flask-Cors==3.0.10
 requests==2.28.1
-python-dotenv==0.21.0

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,7 +1,8 @@
-from flask import Flask, make_response
+from flask import Flask, make_response, request
 from flask_cors import CORS
 from src.db_demo import db_demo
 from src.db_helper import close_db
+from src.recommend_tracks import recommend_tracks
 
 
 def create_app():
@@ -17,5 +18,10 @@ def create_app():
         response = make_response(db_demo(), 200)
         response.headers["Content-Type"] = "application/json"
         return response
+    
+    @app.route("/recommend-tracks", methods = ['POST'])
+    def recommend_tracks_endpoint():
+        track_uris = request.form.getlist("data")
+        return recommend_tracks(track_uris)
 
     return app

--- a/backend/src/recommend_tracks.py
+++ b/backend/src/recommend_tracks.py
@@ -1,0 +1,32 @@
+import requests
+from flask import Response, jsonify, make_response
+from typing import List
+from src.spotify_helper import get_access_token
+
+
+def recommend_tracks(track_uris: List[str]) -> Response:
+    access_token = get_access_token()
+    if access_token is None:
+        return make_response(jsonify([]), 401) # unauthorized
+
+    # TODO: pass track_uris to ML script and get back a list of recommendations
+    recommended_track_uris = ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params = {"ids": ",".join(recommended_track_uris)}
+    response = requests.get("https://api.spotify.com/v1/tracks", headers=headers, params=params)
+
+    tracks = []
+    if response.status_code == 200:
+        for track in response.json()["tracks"]:
+            images = track["album"]["images"]
+            image_url = None if len(images) == 0 else images[0]["url"] # first image is the largest one
+            tracks.append({
+                "name": track["name"],
+			    "artists": list(map(lambda artist: artist["name"], track["artists"])),
+                "image_url": image_url
+            })
+
+    ret_res = make_response(jsonify(tracks), response.status_code)
+    ret_res.headers["Content-Type"] = "application/json"
+    return ret_res

--- a/backend/src/recommend_tracks.py
+++ b/backend/src/recommend_tracks.py
@@ -10,6 +10,7 @@ def recommend_tracks(track_uris: List[str]) -> Response:
         return make_response(jsonify([]), 401) # unauthorized
 
     # TODO: pass track_uris to ML script and get back a list of recommendations
+    # for now, use these 2 arbitrary track_uris as mock
     recommended_track_uris = ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
 
     headers = {"Authorization": f"Bearer {access_token}"}

--- a/backend/src/recommend_tracks.py
+++ b/backend/src/recommend_tracks.py
@@ -7,21 +7,24 @@ from src.spotify_helper import get_access_token
 def recommend_tracks(track_uris: List[str]) -> Response:
     access_token = get_access_token()
     if access_token is None:
-        return make_response(jsonify([]), 401) # unauthorized
+        return make_response(jsonify([]), 401)  # unauthorized
 
     # TODO: pass track_uris to ML script and get back a list of recommendations
     # for now, use these 2 arbitrary track_uris as mock
-    recommended_track_uris = ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
+    recommended_track_uris = [
+        "0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
 
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"ids": ",".join(recommended_track_uris)}
-    response = requests.get("https://api.spotify.com/v1/tracks", headers=headers, params=params)
+    response = requests.get(
+        "https://api.spotify.com/v1/tracks", headers=headers, params=params)
 
     tracks = []
     if response.status_code == 200:
         for track in response.json()["tracks"]:
             images = track["album"]["images"]
-            image_url = None if len(images) == 0 else images[0]["url"] # first image is the largest one
+            # first image is the largest one
+            image_url = None if len(images) == 0 else images[-1]["url"]
             tracks.append({
                 "name": track["name"],
                 "artists": list(map(lambda artist: artist["name"], track["artists"])),

--- a/backend/src/recommend_tracks.py
+++ b/backend/src/recommend_tracks.py
@@ -24,7 +24,7 @@ def recommend_tracks(track_uris: List[str]) -> Response:
             image_url = None if len(images) == 0 else images[0]["url"] # first image is the largest one
             tracks.append({
                 "name": track["name"],
-			    "artists": list(map(lambda artist: artist["name"], track["artists"])),
+                "artists": list(map(lambda artist: artist["name"], track["artists"])),
                 "image_url": image_url
             })
 

--- a/backend/src/spotify_helper.py
+++ b/backend/src/spotify_helper.py
@@ -1,12 +1,7 @@
 from typing import Optional
 import requests
 import os
-from dotenv import load_dotenv
 
-
-# Make sure you have a .env file with the correct CLIENT_ID and CLIENT_SECRET to use the Spotify API.
-# If you don't have the correct .env, you get it from our project Discord chat's pinned messages.
-load_dotenv()
 
 def get_access_token() -> Optional[str]:
     response = requests.post("https://accounts.spotify.com/api/token", {

--- a/backend/src/spotify_helper.py
+++ b/backend/src/spotify_helper.py
@@ -1,0 +1,21 @@
+from typing import Optional
+import requests
+import os
+from dotenv import load_dotenv
+
+
+# Make sure you have a .env file with the correct CLIENT_ID and CLIENT_SECRET to use the Spotify API.
+# If you don't have the correct .env, you get it from our project Discord chat's pinned messages.
+load_dotenv()
+
+def get_access_token() -> Optional[str]:
+    response = requests.post("https://accounts.spotify.com/api/token", {
+        "grant_type": "client_credentials",
+        "client_id": os.environ.get("CLIENT_ID"),
+        "client_secret": os.environ.get("CLIENT_SECRET"),
+    })
+    
+    if response.status_code == 200:
+        return response.json()["access_token"]
+    else:
+        return None

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -23,6 +23,7 @@ def test_query_db(client):
     assert "query" in keys
     assert "result" in keys
 
+
 def test_recommend_tracks_endpoint(client):
     response = client.post("/recommend-tracks", data={
         "data": ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -26,7 +26,13 @@ def test_query_db(client):
 
 def test_recommend_tracks_endpoint(client):
     response = client.post("/recommend-tracks", data={
-        "data": ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
+        "data": [
+			"0UaMYEvWZi0ZqiDOoHU3YI",
+			"6I9VzXrHxO9rA9A5euc8Ak",
+			"0WqIKmW4BTrj3eJFmnCKMv",
+			"1AWQoqb9bSvzTjaLralEkT",
+			"1lzr43nnXAijIGYnCT8M8H"
+		]
     })
     assert response.status_code == 200
     assert isinstance(response.json, List)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,4 @@
+from typing import List
 from ..src.main import create_app
 import pytest
 
@@ -21,3 +22,16 @@ def test_query_db(client):
     keys = response.json.keys()
     assert "query" in keys
     assert "result" in keys
+
+def test_recommend_tracks_endpoint(client):
+    response = client.post("/recommend-tracks", data={
+        "data": ["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
+    })
+    assert response.status_code == 200
+    assert isinstance(response.json, List)
+    for track in response.json:
+        keys = track.keys()
+        assert "name" in keys
+        assert "artists" in keys
+        assert isinstance(track["artists"], List)
+        assert "image_url" in keys

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -32,7 +32,7 @@ def test_recommend_tracks_endpoint(client):
             "0WqIKmW4BTrj3eJFmnCKMv",
             "1AWQoqb9bSvzTjaLralEkT",
             "1lzr43nnXAijIGYnCT8M8H"
-	    ]
+        ]
     })
     assert response.status_code == 200
     assert isinstance(response.json, List)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,3 +1,4 @@
+import json
 from typing import List
 from ..src.main import create_app
 import pytest
@@ -24,8 +25,42 @@ def test_query_db(client):
     assert "result" in keys
 
 
+def test_recommend_tracks_endpoint_bad_request(client):
+    response = client.post("/recommend-tracks")
+    assert response.status_code == 400
+    assert response.json["error"] == "content_type must be application/json"
+
+
+def test_recommend_tracks_endpoint_bad_request_2(client):
+    response = client.post("/recommend-tracks", data=json.dumps({}))
+    assert response.status_code == 400
+    assert response.json["error"] == "content_type must be application/json"
+
+
+def test_recommend_tracks_endpoint_bad_request_3(client):
+    response = client.post(
+        "/recommend-tracks", data=json.dumps({}), content_type='application/json')
+    assert response.status_code == 400
+    assert response.json["error"] == "POST data must include `data` field"
+
+
+def test_recommend_tracks_endpoint_bad_request_4(client):
+    response = client.post("/recommend-tracks", data=json.dumps({
+        "data": [
+            "0UaMYEvWZi0ZqiDOoHU3YI",
+            "6I9VzXrHxO9rA9A5euc8Ak",
+            "0WqIKmW4BTrj3eJFmnCKMv",
+            "1AWQoqb9bSvzTjaLralEkT",
+            "1lzr43nnXAijIGYnCT8M8H",
+            "1lzr43nnXAijIGYnCT8M8H"
+        ]
+    }), content_type='application/json')
+    assert response.status_code == 400
+    assert response.json["error"] == "data must be a list of 1-5 track_uris"
+
+
 def test_recommend_tracks_endpoint(client):
-    response = client.post("/recommend-tracks", data={
+    response = client.post("/recommend-tracks", data=json.dumps({
         "data": [
             "0UaMYEvWZi0ZqiDOoHU3YI",
             "6I9VzXrHxO9rA9A5euc8Ak",
@@ -33,7 +68,7 @@ def test_recommend_tracks_endpoint(client):
             "1AWQoqb9bSvzTjaLralEkT",
             "1lzr43nnXAijIGYnCT8M8H"
         ]
-    })
+    }), content_type='application/json')
     assert response.status_code == 200
     assert isinstance(response.json, List)
     for track in response.json:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,11 +27,11 @@ def test_query_db(client):
 def test_recommend_tracks_endpoint(client):
     response = client.post("/recommend-tracks", data={
         "data": [
-		    "0UaMYEvWZi0ZqiDOoHU3YI",
-		    "6I9VzXrHxO9rA9A5euc8Ak",
-		    "0WqIKmW4BTrj3eJFmnCKMv",
-		    "1AWQoqb9bSvzTjaLralEkT",
-		    "1lzr43nnXAijIGYnCT8M8H"
+            "0UaMYEvWZi0ZqiDOoHU3YI",
+            "6I9VzXrHxO9rA9A5euc8Ak",
+            "0WqIKmW4BTrj3eJFmnCKMv",
+            "1AWQoqb9bSvzTjaLralEkT",
+            "1lzr43nnXAijIGYnCT8M8H"
 	    ]
     })
     assert response.status_code == 200

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -27,12 +27,12 @@ def test_query_db(client):
 def test_recommend_tracks_endpoint(client):
     response = client.post("/recommend-tracks", data={
         "data": [
-			"0UaMYEvWZi0ZqiDOoHU3YI",
-			"6I9VzXrHxO9rA9A5euc8Ak",
-			"0WqIKmW4BTrj3eJFmnCKMv",
-			"1AWQoqb9bSvzTjaLralEkT",
-			"1lzr43nnXAijIGYnCT8M8H"
-		]
+		    "0UaMYEvWZi0ZqiDOoHU3YI",
+		    "6I9VzXrHxO9rA9A5euc8Ak",
+		    "0WqIKmW4BTrj3eJFmnCKMv",
+		    "1AWQoqb9bSvzTjaLralEkT",
+		    "1lzr43nnXAijIGYnCT8M8H"
+	    ]
     })
     assert response.status_code == 200
     assert isinstance(response.json, List)

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,6 +14,9 @@ services:
     #   PYTHONPATH: /app
     volumes:
       - ./backend:/app
+    environment:
+      CLIENT_ID: 77b019360235410f81c0904a4ace93ba
+      CLIENT_SECRET: a90e38621cae4a6797a97004abe633b8
 
   frontend:
     container_name: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       FLASK_APP: src/main.py
       FLASK_RUN_HOST: 0.0.0.0
       FLASK_RUN_PORT: 5050
+      CLIENT_ID: 77b019360235410f81c0904a4ace93ba
+      CLIENT_SECRET: a90e38621cae4a6797a97004abe633b8
     volumes:
       - ./backend:/app
 

--- a/frontend/src/components/RecommendedTracks.tsx
+++ b/frontend/src/components/RecommendedTracks.tsx
@@ -1,44 +1,24 @@
-import {
-  QueryClientProvider,
-  QueryClient,
-  useQuery
-} from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+import { getRecommendedTracks } from 'src/lib/api'
 
-import QueryInput from 'components/QueryInput'
-import RecommendedTracks from 'components/RecommendedTracks'
-import { getDemoQuery } from 'lib/api'
-
-const App: React.FC = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false
-      }
-    }
-  })
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <div id="App" className="m-2">
-        <p>Hello from App.tsx</p>
-        <QueryInput />
-        <Fetch />
-        <RecommendedTracks />
-      </div>
-    </QueryClientProvider>
-  )
-}
-
-const Fetch: React.FC = () => {
+const RecommendedTracks: React.FC = () => {
   const { data, dataUpdatedAt, isLoading, isError, error } = useQuery(
-    ['db-demo'],
-    getDemoQuery
+    ['recommend-tracks'],
+    getRecommendedTracks
   )
+
+  const Body = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <div className="my-2 rounded-lg bg-gray-200 p-4">
+        <h1 className="font-semibold">Fetch Recommended Tracks</h1>
+        <div>{children}</div>
+      </div>
+    )
+  }
 
   if (isLoading)
     return (
-      <div className="my-2 rounded-lg bg-gray-200 p-4">
-        <h1 className="font-semibold ">Fetch data from backend</h1>
+      <Body>
         {/* By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL */}
         <svg
           className="mt-1 h-7 w-7 animate-spin text-gray-700"
@@ -69,21 +49,17 @@ const Fetch: React.FC = () => {
             </g>
           </g>
         </svg>
-      </div>
+      </Body>
     )
   if (isError)
     return (
-      <div className="my-2 rounded-lg bg-gray-200 p-4">
-        <h1 className="font-semibold ">Fetch data from backend</h1>
-        <div>
-          <pre>{error?.toString()}</pre>
-        </div>
-      </div>
+      <Body>
+        <pre>{error?.toString()}</pre>
+      </Body>
     )
 
   return (
-    <div className="my-2 rounded-lg bg-gray-200 p-4">
-      <h1 className="font-semibold ">Fetch data from backend</h1>
+    <Body>
       <div>
         Data: <pre>{JSON.stringify(data, null, 2)}</pre>
       </div>
@@ -91,8 +67,8 @@ const Fetch: React.FC = () => {
       <h4 className="mt-1 text-sm text-gray-900">
         Received at {new Date(dataUpdatedAt).toLocaleString()}
       </h4>
-    </div>
+    </Body>
   )
 }
 
-export default App
+export default RecommendedTracks

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,28 @@
 import fetch from 'cross-fetch'
 import { z } from 'zod'
 
-const API_URL = 'http://localhost:5050/'
+const API_URL = 'http://localhost:5050'
 
 /*
  * WARN: Don't forget to add request mock to frontend/tests/setup.ts when
  * adding a new endpoint or tests will break.
  */
 
-export const demoQuery = z
+export const DemoQuery = z
   .object({
     query: z.string(),
     result: z.number()
   })
   .strict()
+
+export const getDemoQuery = async () => {
+  const response = await fetch(`${API_URL}/db-demo`)
+  if (response.status !== 200) {
+    throw new Error('Request to /db-demo failed')
+  }
+  const data = await response.json()
+  return DemoQuery.parse(data)
+}
 
 export const Track = z
   .object({
@@ -23,11 +32,29 @@ export const Track = z
   })
   .strict()
 
-export const getDemoQuery = async () => {
-  const response = await fetch(`${API_URL}db-demo`)
+export const Tracks = Track.array()
+
+export const getRecommendedTracks = async () => {
+  const response = await fetch(`${API_URL}/recommend-tracks`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      data: ['0c6xIDDpzE81m2q797ordA', '3Qm86XLflmIXVm1wcwkgDK']
+    })
+  })
   if (response.status !== 200) {
-    throw new Error('Request to /db-demo failed')
+    throw new Error('Request to /recommend-tracks failed')
   }
   const data = await response.json()
-  return demoQuery.parse(data)
+  try {
+    Tracks.parse(data)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      console.log(error.issues)
+      throw new Error(`Type error ${JSON.stringify(error.issues)}`)
+    }
+  }
+  return Tracks.parse(data)
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,6 +15,14 @@ export const demoQuery = z
   })
   .strict()
 
+export const Track = z
+  .object({
+    name: z.string(),
+    artists: z.string().array(),
+    image_url: z.string().url().nullable()
+  })
+  .strict()
+
 export const getDemoQuery = async () => {
   const response = await fetch(`${API_URL}db-demo`)
   if (response.status !== 200) {

--- a/frontend/tests/lib/Api.test.tsx
+++ b/frontend/tests/lib/Api.test.tsx
@@ -1,10 +1,10 @@
-import { demoQuery, getDemoQuery } from 'lib/api'
+import { DemoQuery, getDemoQuery } from 'lib/api'
 import { responses } from '../setup'
 
 describe('Test lib/api endpoints', () => {
   test('API mock works', async () => {
     const data = await getDemoQuery()
-    expect(demoQuery.parse(data))
+    expect(DemoQuery.parse(data))
     expect(data).toEqual(responses['db-demo'])
   })
 })

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -4,12 +4,29 @@ import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll } from 'vitest'
 
 const responses = {
-  'db-demo': { query: 'Mock query', result: 2 }
+  'db-demo': { query: 'Mock query', result: 2 },
+  'recommend-tracks': [
+    {
+      name: 'Lose Control (feat. Ciara & Fat Man Scoop)',
+      artists: ['Missy Elliott', 'Ciara', 'Fatman Scoop'],
+      image_url:
+        'https://i.scdn.co/image/ab67616d0000b273f1dfae21eaac0d24fb3dcf5a'
+    },
+    {
+      name: 'Toxic',
+      artists: ['Britney Spears'],
+      image_url:
+        'https://i.scdn.co/image/ab67616d0000b273efc6988972cb04105f002cd4'
+    }
+  ]
 }
 
 const handlers = [
   rest.get('http://localhost:5050/db-demo', (_, res, ctx) => {
     return res(ctx.status(200), ctx.json(responses['db-demo']))
+  }),
+  rest.post('http://localhost:5050/recommend-tracks', (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(responses['recommend-tracks']))
   })
 ]
 


### PR DESCRIPTION
Recommendation logic has been mocked with 2 arbitrary tracks since that logic is @pvtstaticvoid's task. I will create another PR later on to change this once the ML script has been written.

@burtlau and @KirillTregubov a note about the `Track` Zod type I created: The `Track` type is the schema for a single track, but the response you get from my endpoint will contain a LIST of tracks. That means you'll need to parse the `response.json()` as a `List<Track>`, not just a `Track`. Not too familiar with how to do that using the Zod library though, so you'll need to figure that out.