### PR TITLE
Implement Recommend Many Tracks Endpoint

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -45,6 +45,22 @@ def create_app():
         else:
             return error_res
     
+    @app.route("/recommend-many-tracks", methods=['POST'])
+    def recommend_many_tracks_endpoint():
+        """
+        Get recommended tracks for a list of track uris. Similar to /recommend-tracks but
+        allows an arbitrary (any) number of track_uris as input.
+
+        Preconditions:
+        - POST body must be JSON
+        - POST body must be a List[str] of >= 1 "track_uris"
+        """
+        error_res = __verify_list(request, 1, None)
+        if error_res is None:
+            return recommend_tracks(request.json["data"])
+        else:
+            return error_res
+    
     @app.route("/general-info")
     def get_general_info_endpoint():
         """
@@ -91,7 +107,9 @@ def create_app():
         
         data = request.json["data"]
         if not isinstance(data, list) or (min_len is not None and len(data) < min_len) or (max_len is not None and len(data) > max_len):
-            return make_response(jsonify({"error": f"data must be a list of {min_len}-{max_len} track_uris"}), 400)
+            min_str = 0 if min_len is None else min_len
+            max_str = "N/A" if max_len is None else max_len
+            return make_response(jsonify({"error": f"data must be a list of {min_str}-{max_str} track_uris"}), 400)
         
         return None
 

--- a/backend/src/methods.py
+++ b/backend/src/methods.py
@@ -1,6 +1,6 @@
 import requests
 from flask import Response, jsonify, make_response
-from typing import List
+from typing import List, Optional
 from src.spotify_helper import get_access_token, get_tracks
 
 
@@ -9,7 +9,7 @@ def recommend_tracks(track_uris: List[str]) -> Response:
     Get recommended tracks for a list of track uris
 
     Preconditions:
-    - track_uris is a list containing 1-5 "track_uris"
+    - track_uris is a list containing >= 1 "track_uris"
     Postconditions:
     - returns a list of 100 recommended "track_uris"
     """
@@ -17,10 +17,7 @@ def recommend_tracks(track_uris: List[str]) -> Response:
     if access_token is None:
         return make_response(jsonify([]), 401)  # unauthorized
 
-    # TODO: pass track_uris to ML script and get back a list of recommendations
-    # for now, use these 2 arbitrary track_uris as mock
-    recommended_track_uris = [
-        "0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"]
+    recommended_track_uris = __recommend_using_ml(track_uris, 2)
 
     headers = {"Authorization": f"Bearer {access_token}"}
     params = {"ids": ",".join(recommended_track_uris)}
@@ -32,6 +29,35 @@ def recommend_tracks(track_uris: List[str]) -> Response:
     ret_res = make_response(jsonify(tracks), response.status_code)
     ret_res.headers["Content-Type"] = "application/json"
     return ret_res
+
+
+def __recommend_using_ml(track_uris: List[str], max_ml_calls: Optional[int]) -> List[str]:
+    segmented = __segment_list(track_uris, 10)
+    if len(segmented) == 0:
+        return []
+    else:
+        recommended = []
+        num_loops = len(segmented) if max_ml_calls is None else min(len(segmented), max_ml_calls)
+        for i in range(num_loops):
+            segment = segmented[i]
+            # TODO: Run ML model on "segment" and extend the "recommended" list by
+            # the first 100 / min(len(segmented), max_ml_calls) items of the list returned by the ML model.
+            recommended.extend(["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"])
+        # TODO: assert len(recommended) should be 100
+        return recommended
+
+
+def __segment_list(lst: List, length: int) -> List[List]:
+    segmented = []
+    current = []
+    for item in lst:
+        current.append(item)
+        if (len(current) == length):
+            segmented.append(current)
+            current = []
+    if len(current) > 0:
+        segmented.append(current)
+    return segmented
 
 
 def search_tracks(query: str) -> Response:

--- a/backend/src/methods.py
+++ b/backend/src/methods.py
@@ -32,22 +32,42 @@ def recommend_tracks(track_uris: List[str]) -> Response:
 
 
 def __recommend_using_ml(track_uris: List[str], max_ml_calls: Optional[int]) -> List[str]:
+    """
+    Return a list of track_uris recommended by the ML model given the input "track_uris".
+    The ML model will be called a maximum of "max_ml_calls" times. If this value is None, the
+    maximum allowed ML model calls of 100 will be used (not recommended).
+
+    Preconditions:
+    - max_ml_calls is None or 0 < max_ml_calls <= 100
+    Postconditions:
+    - returns a list of len == 100
+    """
     segmented = __segment_list(track_uris, 10)
     if len(segmented) == 0:
         return []
-    else:
-        recommended = []
-        num_loops = len(segmented) if max_ml_calls is None else min(len(segmented), max_ml_calls)
-        for i in range(num_loops):
-            segment = segmented[i]
-            # TODO: Run ML model on "segment" and extend the "recommended" list by
-            # the first 100 / min(len(segmented), max_ml_calls) items of the list returned by the ML model.
-            recommended.extend(["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"])
-        # TODO: assert len(recommended) should be 100
-        return recommended
+    recommended = []
+    num_loops = min(len(segmented), 100 if max_ml_calls is None else max_ml_calls)
+    for i in range(num_loops):
+        segment = segmented[i]
+        # TODO: Run ML model on "segment" and extend the "recommended" list by
+        # the first 100 / min(len(segmented), max_ml_calls) items of the list returned by the ML model.
+        recommended.extend(["0UaMYEvWZi0ZqiDOoHU3YI", "6I9VzXrHxO9rA9A5euc8Ak"])
+    # TODO: assert len(recommended) should be 100
+    return recommended
 
 
 def __segment_list(lst: List, length: int) -> List[List]:
+    """
+    Segment the given lst into nested lists each with at most "length" elements. Each nested list
+    will have "length" elements EXCEPT for the last one which will have the left over len(lst) % length
+    elements.
+
+    Preconditions:
+    - length >= 1
+    Postconditions:
+    - The last nested list in the returned list has len == len(lst) % length. Every other list has
+      len == length.
+    """
     segmented = []
     current = []
     for item in lst:

--- a/backend/src/methods.py
+++ b/backend/src/methods.py
@@ -60,13 +60,14 @@ def __segment_list(lst: List, length: int) -> List[List]:
     """
     Segment the given lst into nested lists each with at most "length" elements. Each nested list
     will have "length" elements EXCEPT for the last one which will have the left over len(lst) % length
-    elements.
+    elements. If "length" divides len(lst), then the last nested list will also have "length" elements.
 
     Preconditions:
     - length >= 1
     Postconditions:
-    - The last nested list in the returned list has len == len(lst) % length. Every other list has
-      len == length.
+    - If len(lst) % length == 0, each nested list in the returned list will have "length" elements.
+      Otherwise, the last nested list in the returned list has len == len(lst) % length while
+      every other list has "length" elements.
     """
     segmented = []
     current = []

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -60,7 +60,6 @@ def test_recommend_tracks_endpoint(client):
     docker = os.environ.get("USING_DOCKER")
     if type(docker) == str and docker.lower() == 'true':
         assert response.status_code == 200
-        assert len(response.json) == 2
         assert isinstance(response.json, List)
         for track in response.json:
             keys = track.keys()
@@ -188,5 +187,66 @@ def test_get_audio_features_endpoint(client):
         assert response.status_code == 200
         assert isinstance(response.json, list)
         assert len(response.json) == 5
+    else:
+        assert response.status_code == 401
+
+
+# Recommend many tracks
+def test_recommend_many_tracks_endpoint_no_input(client):
+    response = client.post("/recommend-many-tracks")
+    assert response.status_code == 400
+    assert response.json["error"] == "content_type must be application/json"
+
+
+def test_recommend_many_tracks_endpoint_no_content_type(client):
+    response = client.post("/recommend-many-tracks", data=json.dumps({}))
+    assert response.status_code == 400
+    assert response.json["error"] == "content_type must be application/json"
+
+
+def test_recommend_many_tracks_endpoint_no_data_field(client):
+    response = client.post(
+        "/recommend-many-tracks", data=json.dumps({}), content_type='application/json')
+    assert response.status_code == 400
+    assert response.json["error"] == "request body must contain a data field"
+
+
+def test_recommend_many_tracks_endpoint_empty_input(client):
+    response = client.post("/recommend-many-tracks", data=json.dumps({
+        "data": []
+    }), content_type='application/json')
+    assert response.status_code == 400
+    assert response.json["error"] == "data must be a list of 1-N/A track_uris"
+
+
+def test_recommend_many_tracks_endpoint(client):
+    response = client.post("/recommend-many-tracks", data=json.dumps({
+        "data": [
+            "0UaMYEvWZi0ZqiDOoHU3YI",
+            "6I9VzXrHxO9rA9A5euc8Ak",
+            "0WqIKmW4BTrj3eJFmnCKMv",
+            "1AWQoqb9bSvzTjaLralEkT",
+            "1lzr43nnXAijIGYnCT8M8H",
+            "0UaMYEvWZi0ZqiDOoHU3YI",
+            "6I9VzXrHxO9rA9A5euc8Ak",
+            "0WqIKmW4BTrj3eJFmnCKMv",
+            "1AWQoqb9bSvzTjaLralEkT",
+            "1lzr43nnXAijIGYnCT8M8H",
+            "0WqIKmW4BTrj3eJFmnCKMv",
+            "1AWQoqb9bSvzTjaLralEkT",
+            "1lzr43nnXAijIGYnCT8M8H"
+        ]
+    }), content_type='application/json')
+    # TODO: Fix API key
+    docker = os.environ.get("USING_DOCKER")
+    if type(docker) == str and docker.lower() == 'true':
+        assert response.status_code == 200
+        assert isinstance(response.json, List)
+        for track in response.json:
+            keys = track.keys()
+            assert "name" in keys
+            assert "artists" in keys
+            assert isinstance(track["artists"], List)
+            assert "images" in keys
     else:
         assert response.status_code == 401


### PR DESCRIPTION
This PR implements the endpoint to recommend tracks given a list of `track_uri`s of arbitrary length.

The ML model part is still left as a TODO since I'm not branched off from Roger's code, so right now it still returns hard-coded data. I'll open another PR to hook up the ML model code once Roger's code gets merged into dev.

Other changes
- Fixed bug in tests: Removed length == 2 check in recommend-tracks-endpoint test. That wasn't the length of the list we'll actually return, that was just the length of the hard-coded list.