### PR TITLE
Implement Caching for Spotify Access Token

### DIFF
--- a/backend/src/spotify_helper.py
+++ b/backend/src/spotify_helper.py
@@ -1,31 +1,66 @@
 from src.response_handler import log_error_res
-from typing import Optional, List, Tuple
+from typing import Any, Dict, Optional, List, Tuple
 import requests
 import os
 import logging
+import datetime as dt
+
+
+token_cache: Dict[str, Any] = {
+    "token": "",
+    "expires_in": 0,
+    "access_time": dt.datetime.today()
+}
+
+
+credentials_cache: Dict[str, str] = {
+    "client_id": "",
+    "client_secret": ""
+}
 
 
 def get_access_token() -> Optional[str]:
     logging.info("get_access_token()")
-    credentials = get_client_credentials()
-    if credentials is None:
-        return None
-    
-    response = requests.post("https://accounts.spotify.com/api/token", {
-        "grant_type": "client_credentials",
-        "client_id": credentials[0],
-        "client_secret": credentials[1],
-    })
-    
-    if response.status_code == 200:
-        return response.json()["access_token"]
+    if (dt.datetime.today() - token_cache["access_time"]).total_seconds() < token_cache["expires_in"] - 10:
+        # token hasn't expired yet (10 second buffer)
+        logging.debug("get access token from CACHE")
+
+        return token_cache["token"]
     else:
-        log_error_res(response, "POST")
-        return None
+        # token has expired; get a new one
+        logging.debug("get access token from REQUEST")
+
+        credentials = get_client_credentials()
+        if credentials is None:
+            return None
+
+        response = requests.post("https://accounts.spotify.com/api/token", {
+            "grant_type": "client_credentials",
+            "client_id": credentials[0],
+            "client_secret": credentials[1],
+        })
+
+        if response.status_code == 200:
+            data = response.json()
+            token_cache["token"] = data["access_token"]
+            token_cache["expires_in"] = data["expires_in"]
+            token_cache["access_time"] = dt.datetime.today() # getting new time again bc request takes time
+            return data["access_token"]
+        else:
+            log_error_res(response, "POST")
+            return None
 
 
 def get_client_credentials() -> Optional[Tuple[str, str]]:
     logging.info("get_client_credentials()")
+    cached_client_id = credentials_cache["client_id"]
+    cached_client_secret = credentials_cache["client_secret"]
+
+    if cached_client_id and cached_client_secret:
+        logging.debug("get client creds from CACHE")
+        return cached_client_id, cached_client_secret
+
+    logging.debug("get client creds from ENV or FILE")
     client_id = os.environ.get("CLIENT_ID")
     client_secret = os.environ.get("CLIENT_SECRET")
     
@@ -38,7 +73,9 @@ def get_client_credentials() -> Optional[Tuple[str, str]]:
         except (OSError, IndexError):
             logging.error("secrets.txt is either missing or in the wrong format.")
             return None
-    
+
+    credentials_cache["client_id"] = client_id
+    credentials_cache["client_secret"] = client_secret
     return client_id, client_secret
 
 


### PR DESCRIPTION
This PR adds caching for both the access token and client credentials.

Access token caching is needed because HTTP requests are expensive and tokens last for 1 hour.
Client credentials caching is needed because reading files is expensive and credentials never change.